### PR TITLE
Support basic auth

### DIFF
--- a/src/main/java/uk/gov/admin/Loader.java
+++ b/src/main/java/uk/gov/admin/Loader.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.jcabi.http.Request;
 import com.jcabi.http.Response;
 import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.wire.BasicAuthWire;
 
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
@@ -45,6 +46,7 @@ class Loader {
 
     protected Response makeRestCallToLoadEntryBatch(List<String> batch) throws IOException {
         return new JdkRequest(mintUrl)
+                .through(BasicAuthWire.class)
                 .method(Request.POST)
                 .body()
                 .set(String.join("\n", batch))


### PR DESCRIPTION
We've hidden the loader endpoint behind a HTTP Basic Auth filter (temporarily). The Loader needs changing to support this. If we add the Basic Auth throughwiring class, JCabi will process http://user:pass@host and convert the user/pass into an HTTP Basic Auth header properly.
