### PR TITLE
Increase entries batch size to 1000

### DIFF
--- a/src/main/java/uk/gov/admin/Loader.java
+++ b/src/main/java/uk/gov/admin/Loader.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 
 class Loader {
-    private static final int BATCH_SIZE = 10;
+    private static final int BATCH_SIZE = 1000;
 
     private final String mintUrl;
     private long entryCount = 0;


### PR DESCRIPTION
It used to be 2000 but was reduced to 10 by Andrew while working on Certificate Transparency spike.

We are not using CT now and 10 is very small batch size and also takes comparatively long time to load the data, so increased to 1000.
