### PR TITLE
prune keys with whitespace value

### DIFF
--- a/src/main/java/uk/gov/admin/EmptyFieldPruner.java
+++ b/src/main/java/uk/gov/admin/EmptyFieldPruner.java
@@ -1,6 +1,5 @@
 package uk.gov.admin;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Maps;
 
 import java.util.List;
@@ -8,20 +7,15 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 class EmptyFieldPruner {
-    private final Predicate<Map.Entry> keyHasNonEmptyValue = i -> {
-        if (i == null) {
-            return false;
-        } else if (i.getValue() instanceof String && ((String) i.getValue()).isEmpty()) {
-            return false;
-        }
-        return true;
-    };
-
     public Map removeKeysWithEmptyValues(Map input) {
-        return Maps.filterEntries(input, keyHasNonEmptyValue);
+        return Maps.filterEntries(input, e -> !isValueNullOrBlank(e));
     }
 
     public List<Map> removeKeysWithEmptyValues(List<Map> input) {
         return input.stream().map(this::removeKeysWithEmptyValues).collect(Collectors.toList());
+    }
+
+    private boolean isValueNullOrBlank(Map.Entry e) {
+        return e == null || e.getValue().toString().trim().isEmpty();
     }
 }

--- a/src/test/java/uk/gov/admin/EmptyFieldPrunerTest.java
+++ b/src/test/java/uk/gov/admin/EmptyFieldPrunerTest.java
@@ -2,15 +2,25 @@ package uk.gov.admin;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class EmptyFieldPrunerTest {
+    @Test
+    public void nonStringTypeValue_remainsIntact() {
+        Map testData = Collections.singletonMap("fields", Arrays.asList("a", "b"));
+        Map result = new EmptyFieldPruner().removeKeysWithEmptyValues(testData);
+        assertThat(result.size(), is(1));
+        assertThat(result.get("fields").toString(), equalTo("[a, b]"));
+    }
+
     @Test
     public void emptyValue_causesKeyRemoval() {
         Map<String, String> testData = Collections.singletonMap("key", "");
@@ -27,6 +37,8 @@ public class EmptyFieldPrunerTest {
         testData.put("k2", "");
         testData.put("k3", "v3");
         testData.put("k4", "");
+        testData.put("k5", " ");
+        testData.put("k6", "             ");
 
 
         Map result = new EmptyFieldPruner().removeKeysWithEmptyValues(testData);
@@ -35,6 +47,8 @@ public class EmptyFieldPrunerTest {
         assertThat(result.get("k2"), is(nullValue()));
         assertThat(result.get("k3"), is("v3"));
         assertThat(result.get("k4"), is(nullValue()));
+        assertThat(result.get("k5"), is(nullValue()));
+        assertThat(result.get("k6"), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
EmptyFieldPruner was not pruning keys with values as whitespace. Changes in PR does that so that we don't load entries with field value as whitespace.
